### PR TITLE
allow gsea_gmt_parser to accept file-like inputs

### DIFF
--- a/gseapy/parser.py
+++ b/gseapy/parser.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, print_function
 from bs4 import BeautifulSoup
 from numpy import in1d, unique
 from pandas import read_table
-
+from pandas.io.common import get_filepath_or_buffer
 import sys
 
 
@@ -83,11 +83,11 @@ def gsea_gmt_parser(gmt, min_size = 3, max_size = 5000, gene_list=None):
     do this for you.
             
     """
-       
-    with open(gmt) as genesets:
-        genesets_dict = { line.rstrip("\n").split("\t")[0]:  
-                          line.rstrip("\n").split("\t")[2:] 
-                          for line in genesets.readlines()}    
+ 
+    file_or_buffer, encode, compression = get_filepath_or_buffer(gmt)
+    genesets_dict = { line.rstrip("\n").split("\t")[0]:  
+                      line.rstrip("\n").split("\t")[2:] 
+                      for line in file_or_buffer.readlines()}    
     #filtering dict
     if sys.version_info[0] == 3 :
         genesets_filter =  {k: v for k, v in genesets_dict.items() if len(v) >= min_size and len(v) <= max_size}


### PR DESCRIPTION
gsea_gmt_parser assumes the input is a url (file path). This slightly limit functionality, as users may want to pass a generated gene_sets buffer to functions like gseapy.prerank.

This patch utilize pandas' get_filepath_or_buffer to make gsea_gmt_parser capable to handle both file paths and buffers.